### PR TITLE
Improve docstrings for core_selection

### DIFF
--- a/src/multiplex_pipeline/core_selection/suggest_cores.py
+++ b/src/multiplex_pipeline/core_selection/suggest_cores.py
@@ -20,9 +20,14 @@ from utils import get_workstation_path
 from im_utils import prepare_rgb_image
 
 def set_cuda(model_path):
-    '''
-    Function to set the environment for sam2 segmentation.
-    '''
+    """Configure CUDA settings for SAM2 segmentation.
+
+    Args:
+        model_path (str): Path to the directory with the SAM2 model.
+
+    Returns:
+        tuple[torch.device, str, str]: CUDA device, checkpoint path and model configuration path.
+    """
     assert torch.cuda.is_available()
 
     device = torch.device("cuda")
@@ -31,10 +36,27 @@ def set_cuda(model_path):
 
     return device,sam2_checkpoint,model_cfg
 
-def sam2_segment(im_rgb,build_sam2,SAM2AutomaticMaskGenerator, device,sam2_checkpoint,model_cfg):
-    '''
-    Function to segment the image using the sam2 model.
-    '''
+def sam2_segment(
+    im_rgb,
+    build_sam2,
+    SAM2AutomaticMaskGenerator,
+    device,
+    sam2_checkpoint,
+    model_cfg,
+):
+    """Segment an RGB image using the SAM2 model.
+
+    Args:
+        im_rgb (numpy.ndarray): RGB image to segment.
+        build_sam2 (Callable): Function that builds a SAM2 model instance.
+        SAM2AutomaticMaskGenerator (Callable): Mask generator class.
+        device (torch.device): CUDA device used for inference.
+        sam2_checkpoint (str): Path to the SAM2 checkpoint file.
+        model_cfg (str): Path to the SAM2 configuration file.
+
+    Returns:
+        list[dict]: Segmentation masks for the input image.
+    """
 
     # clear the cache
     torch.cuda.empty_cache()

--- a/src/multiplex_pipeline/core_selection/viewer_utils.py
+++ b/src/multiplex_pipeline/core_selection/viewer_utils.py
@@ -5,39 +5,66 @@ from qtpy.QtWidgets import QFileDialog
 from multiplex_pipeline.roi_utils import read_in_saved_rois, prepare_poly_df_for_saving, get_visual_rectangles
 
 
-def redo_cores_layer(viewer,data=[],shape_type='polygon'):
+def redo_cores_layer(viewer, data=[], shape_type="polygon"):
+    """Create or replace the ``cores`` layer in a viewer.
 
-    if 'cores' in viewer.layers:
-        viewer.layers.remove('cores')
+    Args:
+        viewer (napari.Viewer): Viewer instance to update.
+        data (list, optional): Vertices describing the shapes. Defaults to ``[]``.
+        shape_type (str, optional): Napari shape type. Defaults to ``"polygon"``.
+
+    Returns:
+        None
+    """
+
+    if "cores" in viewer.layers:
+        viewer.layers.remove("cores")
 
     viewer.add_shapes(
-    data,       
-    shape_type=shape_type,  
-    edge_color='green', 
-    face_color='transparent',  
-    edge_width=2,       
-    name = 'cores'
-)
+        data,
+        shape_type=shape_type,
+        edge_color="green",
+        face_color="transparent",
+        edge_width=2,
+        name="cores",
+    )
     
-def redo_bbox_layer(viewer,data=[],text=[]):
+def redo_bbox_layer(viewer, data=[], text=[]):
+    """Create or replace the ``bounding_boxes`` layer in a viewer.
 
-    if 'bounding_boxes' in viewer.layers:
-        viewer.layers.remove('bounding_boxes')
+    Args:
+        viewer (napari.Viewer): Viewer instance to update.
+        data (list, optional): Rectangle coordinates. Defaults to ``[]``.
+        text (list, optional): Labels shown next to rectangles. Defaults to ``[]``.
+
+    Returns:
+        None
+    """
+
+    if "bounding_boxes" in viewer.layers:
+        viewer.layers.remove("bounding_boxes")
 
     viewer.add_shapes(
-    data,       
-    shape_type='rectangle',  
-    edge_color='red', 
-    face_color='transparent',  
-    edge_width=2,       
-    name = 'bounding_boxes',
-    text = {'string': text,'size':12,'color':'red','anchor':'upper_left'}
-) 
+        data,
+        shape_type="rectangle",
+        edge_color="red",
+        face_color="transparent",
+        edge_width=2,
+        name="bounding_boxes",
+        text={"string": text, "size": 12, "color": "red", "anchor": "upper_left"},
+    )
 
-def display_saved_rois(viewer, IM_LEVEL, save_path = None):
-    '''
-    Display the saved rois from the file in the viewer.
-    '''
+def display_saved_rois(viewer, IM_LEVEL, save_path=None):
+    """Load ROI annotations from disk and show them in the viewer.
+
+    Args:
+        viewer (napari.Viewer): Viewer instance where layers are added.
+        IM_LEVEL (int): Image pyramid level used when the ROIs were saved.
+        save_path (str, optional): File path of the saved ROIs. Defaults to ``None``.
+
+    Returns:
+        None
+    """
     rect_list, poly_list, df = read_in_saved_rois(save_path, IM_LEVEL = IM_LEVEL)
     if len(rect_list) > 0:
         redo_bbox_layer(viewer,rect_list,df['core_name'].tolist())
@@ -45,9 +72,18 @@ def display_saved_rois(viewer, IM_LEVEL, save_path = None):
     else:
         viewer.status = 'No previous rois found!'
 
-def save_rois_from_viewer(viewer, org_im_shape, req_level, save_path = None):
-    '''
-    '''
+def save_rois_from_viewer(viewer, org_im_shape, req_level, save_path=None):
+    """Save ROIs drawn in the viewer to disk and update the displayed layers.
+
+    Args:
+        viewer (napari.Viewer): Viewer containing a ``cores`` shapes layer.
+        org_im_shape (tuple[int, int]): Shape of the original image.
+        req_level (int): Resolution level at which the ROIs are defined.
+        save_path (str, optional): Destination CSV file path. Defaults to ``None``.
+
+    Returns:
+        None
+    """
     if 'cores' in viewer.layers:
 
         # get the saving path if not provided


### PR DESCRIPTION
## Summary
- standardize docstrings in viewer_utils and suggest_cores modules
- use Google style for mkdocstrings compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852e7cbe67c8329a40dcf9ed8e53a32